### PR TITLE
Adding play-json to build

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -8,6 +8,7 @@
 #   - scalatestplus-play
 #   - anorm
 #   - play-ebean
+#   - play-json
 #   - play-slick
 #   - twirl
 #   - omnidoc
@@ -21,6 +22,7 @@ declare PLAY_BRANCH="master"
 declare SCALATESTPLUS_PLAY_BRANCH="master"
 declare ANORM_BRANCH="master"
 declare PLAY_EBEAN_BRANCH="master"
+declare PLAY_JSON_BRANCH="master"
 declare PLAY_SLICK_BRANCH="master"
 declare TWIRL_BRANCH="master"
 
@@ -93,6 +95,9 @@ ANORM_VERSION=$(extract_version)
 checkout $DEPLOY/play-ebean $PLAY_EBEAN_BRANCH
 PLAY_EBEAN_VERSION=$(extract_version)
 
+checkout $DEPLOY/play-json $PLAY_JSON_BRANCH
+PLAY_JSON_VERSION=$(extract_version)
+
 checkout $DEPLOY/play-slick $PLAY_SLICK_BRANCH
 PLAY_SLICK_VERSION=$(extract_version)
 
@@ -108,6 +113,7 @@ echo "               play: $PLAY_VERSION"
 echo " scalatestplus-play: $SCALATESTPLUS_PLAY_VERSION"
 echo "              anorm: $ANORM_VERSION"
 echo "         play-ebean: $PLAY_EBEAN_VERSION"
+echo "          play-json: $PLAY_JSON_VERSION"
 echo "         play-slick: $PLAY_SLICK_VERSION"
 echo "              twirl: $TWIRL_VERSION"
 echo "            omnidoc: $PLAY_VERSION"
@@ -126,7 +132,7 @@ echo --- play $PLAY_VERSION
 echo
 
 cd $DEPLOY/playframework/framework
-./build -Dtwirl.version=$TWIRL_VERSION +publishLocal
+build -Dtwirl.version=$TWIRL_VERSION +publishLocal
 
 echo
 echo --- scalatestplus-play $SCALATESTPLUS_PLAY_VERSION
@@ -150,6 +156,13 @@ cd $DEPLOY/play-ebean
 build +publishLocal plugin/publishLocal
 
 echo
+echo --- play-json $PLAY_JSON_VERSION
+echo
+
+cd $DEPLOY/play-json
+build +publishLocal
+
+echo
 echo --- play-slick $PLAY_SLICK_VERSION
 echo
 
@@ -165,6 +178,7 @@ versions="$versions -Dplay.version=$PLAY_VERSION"
 versions="$versions -Dscalatestplus-play.version=$SCALATESTPLUS_PLAY_VERSION"
 versions="$versions -Danorm.version=$ANORM_VERSION"
 versions="$versions -Dplay-ebean.version=$PLAY_EBEAN_VERSION"
+versions="$versions -Dplay-json.version=$PLAY_JSON_VERSION"
 versions="$versions -Dplay-slick.version=$PLAY_SLICK_VERSION"
 versions="$versions -Dtwirl.version=$TWIRL_VERSION"
 

--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -18,6 +18,7 @@ object OmnidocBuild extends Build {
   val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "2.0.0-M2")
   val anormVersion             = sys.props.getOrElse("anorm.version",              "2.6.0-M1")
   val playEbeanVersion         = sys.props.getOrElse("play-ebean.version",         "4.0.0-M1")
+  val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.6.0-M4")
   val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "3.0.0-M2")
   val maybeTwirlVersion        = sys.props.get("twirl.version")
 
@@ -39,6 +40,8 @@ object OmnidocBuild extends Build {
     playOrganisation %% "anorm"                 % anormVersion,
     scalaTestPlusPlayOrganisation %% "scalatestplus-play" % scalaTestPlusPlayVersion,
     playOrganisation %% "play-ebean"            % playEbeanVersion,
+    playOrganisation %% "play-functional"       % playJsonVersion,
+    playOrganisation %% "play-json"             % playJsonVersion,
     playOrganisation %% "play-slick"            % playSlickVersion,
     playOrganisation %% "play-slick-evolutions" % playSlickVersion
   )
@@ -135,7 +138,13 @@ object OmnidocBuild extends Build {
   )
 
   def scaladocSettings: Seq[Setting[_]] = Defaults.docTaskSettings(scaladoc) ++ Seq(
-          sources in scaladoc := (sources.value ** "*.scala").get,
+          sources in scaladoc := {
+            val s = sources.value
+            // Exclude a Play JSON file from the Scaladoc build because
+            // it includes a macro from a third party library and we don't
+            // want to deal with bringing extra libraries into Omnidoc.
+            ((s ** "*.scala") --- (s ** "JsMacroImpl.scala")).get
+          },
            target in scaladoc := target.value / "scaladoc",
     scalacOptions in scaladoc := scaladocOptions.value,
                      scaladoc := rewriteSourceUrls(scaladoc.value, sourceUrls.value, "/src/main/scala", ".scala")


### PR DESCRIPTION
This PR updates Omnidoc so it knows about the Play JSON documentation that will soon be moved out of the core Play project and into the Play JSON project itself.

See:
* https://github.com/playframework/playframework/pull/6965
* https://github.com/playframework/play-json/pull/37

**It currently doesn't work, so don't merge it. :)**