### PR TITLE
Remove anorm from published docs

### DIFF
--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -16,7 +16,6 @@ object OmnidocBuild extends Build {
 
   val playVersion              = sys.props.getOrElse("play.version",               "2.7.0")
   val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "4.0.1")
-  val anormVersion             = sys.props.getOrElse("anorm.version",              "2.5.3")
   val playEbeanVersion         = sys.props.getOrElse("play-ebean.version",         "5.0.1")
   val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.7.1")
   val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "4.0.0")
@@ -64,7 +63,6 @@ object OmnidocBuild extends Build {
   )
 
   val playModules = Seq(
-    playOrganisation %% "anorm"                 % anormVersion,
     scalaTestPlusPlayOrganisation %% "scalatestplus-play" % scalaTestPlusPlayVersion,
     playOrganisation %% "play-ebean"            % playEbeanVersion,
     playOrganisation %% "play-functional"       % playJsonVersion,


### PR DESCRIPTION
Updated docs for Anorm now live here: https://playframework.github.io/anorm/