### PR TITLE
[2.7] Revert "back-release for 2.13.0"

### DIFF
--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -118,8 +118,7 @@ object OmnidocBuild {
                                name := "play-omnidoc",
                             version := playVersion,
      playBuildRepoName in ThisBuild := "omnidoc",
-                       scalaVersion := "2.13.0",
-                 crossScalaVersions := Seq("2.13.0")
+                 crossScalaVersions := Seq(ScalaVersions.scala212, ScalaVersions.scala211)
   )
 
   def dependencySettings: Seq[Setting[_]] = Seq(

--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -118,7 +118,7 @@ object OmnidocBuild {
                                name := "play-omnidoc",
                             version := playVersion,
      playBuildRepoName in ThisBuild := "omnidoc",
-                 crossScalaVersions := Seq(ScalaVersions.scala212, ScalaVersions.scala211)
+                 crossScalaVersions := Seq(ScalaVersions.scala213, ScalaVersions.scala212, ScalaVersions.scala211)
   )
 
   def dependencySettings: Seq[Setting[_]] = Seq(

--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -18,7 +18,7 @@ object OmnidocBuild {
 
   val playVersion              = sys.props.getOrElse("play.version",               "2.7.3")
   val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "4.0.3")
-  val playEbeanVersion         = sys.props.getOrElse("play-ebean.version",         "5.0.2")
+  val playEbeanVersion         = sys.props.getOrElse("play-ebean.version",         "5.0.1")
   val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.7.4")
   val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "4.0.2")
   val maybeTwirlVersion        = sys.props.get("twirl.version")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "2.0.8"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "2.0.5"))


### PR DESCRIPTION
This reverts commit e8714528cc2637ebf3a7422c0b5afd0b99a8cb61.

I think that was meant to be only tempoorary.

This showed up as a failure in the nightly deploy stable.

I have _absolutely_ no idea how it "worked" before, but I suspected that it didn't and that now it's more obviously broken.