### PR TITLE
[2.7] Drop play-ebean

### DIFF
--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -18,7 +18,6 @@ object OmnidocBuild {
 
   val playVersion              = sys.props.getOrElse("play.version",               "2.7.3")
   val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "4.0.3")
-  val playEbeanVersion         = sys.props.getOrElse("play-ebean.version",         "5.0.1")
   val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.7.4")
   val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "4.0.2")
   val maybeTwirlVersion        = sys.props.get("twirl.version")
@@ -66,7 +65,6 @@ object OmnidocBuild {
 
   val playModules = Seq(
     scalaTestPlusPlayOrganisation %% "scalatestplus-play" % scalaTestPlusPlayVersion,
-    playOrganisation %% "play-ebean"            % playEbeanVersion,
     playOrganisation %% "play-functional"       % playJsonVersion,
     playOrganisation %% "play-json"             % playJsonVersion,
     playOrganisation %% "play-slick"            % playSlickVersion,


### PR DESCRIPTION
play-ebean is a community-driven, and there's no 2.11 variant for 5.0.2,
nor a 2.13 variant for 5.0.1, so let's just drop it.