### PR TITLE
New play-slick/scatest+play, old play-json

### DIFF
--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -17,9 +17,9 @@ object OmnidocBuild {
   val snapshotVersionLabel = "2.8.x"
 
   val playVersion              = sys.props.getOrElse("play.version",               "2.8.0-M6")
-  val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "5.0.0-M5")
-  val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.8.0-M7")
-  val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "5.0.0-M6")
+  val scalaTestPlusPlayVersion = sys.props.getOrElse("scalatestplus-play.version", "5.0.0-M6")
+  val playJsonVersion          = sys.props.getOrElse("play-json.version",          "2.8.0-M6")
+  val playSlickVersion         = sys.props.getOrElse("play-slick.version",         "5.0.0-M7")
   val maybeTwirlVersion        = sys.props.get("twirl.version")
 
   // List Play artifacts so that they can be added as dependencies


### PR DESCRIPTION
We're not using latest Play JSON, as that brings in a version of Jackson
that conflicts with Akka.  Will be fixed in the RC1 synchronised cycle.