### PR TITLE
[2.7] Update Interplay to 2.1.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "2.0.5"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "2.1.1"))


### PR DESCRIPTION
This upgrade from sbt-pgp 1 to sbt-pgp 2, which will unbreak vegemite
deploying the docs nightly.