### PR TITLE
[2.6] Update Interplay to 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
 language: scala
 
-before_install:
-  - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
-
-install:
-  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
-  - unset _JAVA_OPTIONS
-  - export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
-
 env:
-  global:
-    - JABBA_HOME=$HOME/.jabba
-  matrix:
-    - TRAVIS_JDK=adopt@1.8.192-12
-    - TRAVIS_JDK=adopt@1.11.0-1
+  - TRAVIS_JDK=8
+  - TRAVIS_JDK=11
+
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
 
 matrix:
   fast_finish: true
@@ -21,10 +13,10 @@ matrix:
     # Java 11 is still not fully supported. It is good that we are already
     # testing play-ws using it to better discover possible problems but we
     # can allow failures here too.
-    - env: TRAVIS_JDK=adopt@1.11.0-1
+    - env: TRAVIS_JDK=11
 
 scala:
-  - 2.12.8
+  - 2.12.10
   - 2.11.12
 
 script:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.18"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.19"))


### PR DESCRIPTION
This upgrade from sbt-pgp 1 to sbt-pgp 2, which will unbreak vegemite
deploying the docs nightly.