### PR TITLE
Switch to akka-http 10.1 URL for Javadoc 11

### DIFF
--- a/project/OmnidocBuild.scala
+++ b/project/OmnidocBuild.scala
@@ -321,7 +321,7 @@ object OmnidocBuild {
       "-link",
       "https://doc.akka.io/japi/akka/2.6/",
       "-link",
-      "https://doc.akka.io/japi/akka-http/current/",
+      "https://doc.akka.io/japi/akka-http/10.1/",
       "-notimestamp",
       "-exclude", "play.api:play.core",
       "-Xdoclint:none",


### PR DESCRIPTION
For some reason this URL works, while the first returned:

    [warn] javadoc: error - Error fetching URL: https://doc.akka.io/japi/akka-http/current/