### PR TITLE
travis: Use latest JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - TRAVIS_JDK=11
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
-install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
+install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Switch to using jabba ls-remote with --latest=patch to ensure that the
latest version is used.

Previous if adopt@1.11.0-0 was already installed (via Travis CI's cache)
even though adopt@1.11.0-5 is out, we'd not install it.