### PR TITLE
Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omnidoc
 
-Omnidoc is an sbt build that adds to sbt's `mappings in (Compile, packageBin)` to aggregate source code and manuals produced within the Play ecosystem and produce a single deliverable. This must not be confused with Interplay's [Omnidoc](https://github.com/playframework/interplay/blob/master/src/main/scala/interplay/Omnidoc.scala) which _simply_ adds some metadata on the `-source.jar` artifact of every Play library. 
+Omnidoc is an sbt build that adds to sbt's `mappings in (Compile, packageBin)` to aggregate source code and manuals produced within the Play ecosystem and produce a single deliverable. This must not be confused with Interplay's [Omnidoc](https://github.com/playframework/interplay/blob/main/src/main/scala/interplay/Omnidoc.scala) which _simply_ adds some metadata on the `-source.jar` artifact of every Play library. 
 
 The resulting deliverable includes:
 


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```